### PR TITLE
Setting up unit tests 2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -103,6 +103,7 @@ gradle-app.setting
 /desktop/build/
 /html/build/
 /ios/build/
+/tests/build/
 
 ## OS Specific
 .DS_Store

--- a/README.md
+++ b/README.md
@@ -12,6 +12,9 @@ Create a new layer where the collisions will occur. Edit a tileset and select a 
 For transitions edit a tileset and select a different pixel that you don't use and add a property called transition and give it a value of the file path of where you want the transition to take you.
 
 
+# Tests
+
+The testing part of this code is derived from [TomGrill's libGDX Testing Skeleton](https://github.com/TomGrill/gdx-testing).
 
 # Website
 

--- a/game/build.gradle
+++ b/game/build.gradle
@@ -75,3 +75,44 @@ project("core") {
         implementation 'com.github.blueboxware:libgdxplugin:1.23.1'
     }
 }
+
+project("tests") {
+    apply plugin: "java"
+
+    sourceSets.test.java.srcDirs = ["src/"]
+
+    dependencies {
+
+        /**
+         * If you do have some classes to test in os specific code you may want to uncomment
+         * some of these lines.
+         *
+         * BUT: I recommend to create separate test sub projects for each platform. Trust me :)
+         *
+         */
+
+//        compile project(":android")
+//        compile project(":html")
+//        compile project(":desktop")
+
+
+//        if(System.getProperty("os.name").toLowerCase().indexOf("mac") >= 0) {
+//        	compile project(":ios")
+//        }
+
+        implementation project(":game:core")
+
+        implementation "junit:junit:4.+"
+        implementation "org.mockito:mockito-all:1.9.+"
+
+        implementation "com.badlogicgames.gdx:gdx-backend-headless:$gdxVersion"
+        implementation "com.badlogicgames.gdx:gdx:$gdxVersion"
+
+        testImplementation 'junit:junit:4.+'
+        testImplementation "org.mockito:mockito-all:1.9.+"
+
+        testImplementation "com.badlogicgames.gdx:gdx-backend-headless:$gdxVersion"
+        testImplementation "com.badlogicgames.gdx:gdx:$gdxVersion"
+        testImplementation "com.badlogicgames.gdx:gdx-platform:$gdxVersion:natives-desktop"
+    }
+}

--- a/game/tests/build.gradle
+++ b/game/tests/build.gradle
@@ -1,0 +1,23 @@
+apply plugin: "java"
+
+sourceCompatibility = 11
+[compileJava, compileTestJava]*.options*.encoding = 'UTF-8'
+
+// Gradle throws a "Duplicate content roots" warning for
+// the first line but the tests won't run without it
+sourceSets.main.resources.srcDirs = ["../assets"]
+project.ext.assetsDir = new File("../assets")
+
+sourceSets {
+	test {
+        java {
+            srcDir 'src'
+        }
+    }
+    
+    
+}
+
+eclipse.project {
+    name = appName + "-tests"
+}

--- a/game/tests/src/com/eng1/gdxtesting/AssetTests.java
+++ b/game/tests/src/com/eng1/gdxtesting/AssetTests.java
@@ -1,0 +1,29 @@
+package com.eng1.gdxtesting;
+
+import static org.junit.Assert.assertTrue;
+
+import com.eng1.game.Play;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import com.badlogic.gdx.Gdx;
+
+import com.eng1.gdxtesting.GdxTestRunner;
+
+@RunWith(GdxTestRunner.class)
+public class AssetTests {
+    @Test
+    public void testCharacter1AssetExists() {
+        assertTrue("Testing whether the asset for character 1 exists", Gdx.files.internal(Play.CHAR1).exists());
+    }
+
+    @Test
+    public void testCharacter2AssetExists() {
+        assertTrue("Testing whether the asset for character 2 exists", Gdx.files.internal(Play.CHAR2).exists());
+    }
+
+    @Test
+    public void testCharacter3AssetExists() {
+        assertTrue("Testing whether the asset for character 3 exists", Gdx.files.internal(Play.CHAR3).exists());
+    }
+}

--- a/game/tests/src/com/eng1/gdxtesting/GdxTestRunner.java
+++ b/game/tests/src/com/eng1/gdxtesting/GdxTestRunner.java
@@ -1,0 +1,104 @@
+/*******************************************************************************
+ * Copyright 2015 See AUTHORS file.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ******************************************************************************/
+
+package com.eng1.gdxtesting;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.runner.notification.RunNotifier;
+import org.junit.runners.BlockJUnit4ClassRunner;
+import org.junit.runners.model.FrameworkMethod;
+import org.junit.runners.model.InitializationError;
+
+import com.badlogic.gdx.Gdx;
+import com.badlogic.gdx.graphics.GL20;
+import static org.mockito.Mockito.mock;
+
+import com.badlogic.gdx.ApplicationListener;
+import com.badlogic.gdx.backends.headless.HeadlessApplication;
+import com.badlogic.gdx.backends.headless.HeadlessApplicationConfiguration;
+
+public class GdxTestRunner extends BlockJUnit4ClassRunner implements ApplicationListener {
+
+	private Map<FrameworkMethod, RunNotifier> invokeInRender = new HashMap<FrameworkMethod, RunNotifier>();
+
+	public GdxTestRunner(Class<?> klass) throws InitializationError {
+		super(klass);
+		HeadlessApplicationConfiguration conf = new HeadlessApplicationConfiguration();
+
+		new HeadlessApplication(this, conf);
+		Gdx.gl = mock(GL20.class);
+	}
+
+	@Override
+	public void create() {
+	}
+
+	@Override
+	public void resume() {
+	}
+
+	@Override
+	public void render() {
+		synchronized (invokeInRender) {
+			for (Map.Entry<FrameworkMethod, RunNotifier> each : invokeInRender.entrySet()) {
+				super.runChild(each.getKey(), each.getValue());
+			}
+			invokeInRender.clear();
+		}
+	}
+
+	@Override
+	public void resize(int width, int height) {
+	}
+
+	@Override
+	public void pause() {
+	}
+
+	@Override
+	public void dispose() {
+	}
+
+	@Override
+	protected void runChild(FrameworkMethod method, RunNotifier notifier) {
+		synchronized (invokeInRender) {
+			// add for invoking in render phase, where gl context is available
+			invokeInRender.put(method, notifier);
+		}
+		// wait until that test was invoked
+		waitUntilInvokedInRenderMethod();
+	}
+
+	/**
+	    *
+	    */
+	private void waitUntilInvokedInRenderMethod() {
+		try {
+			while (true) {
+				Thread.sleep(10);
+				synchronized (invokeInRender) {
+					if (invokeInRender.isEmpty())
+						break;
+				}
+			}
+		} catch (InterruptedException e) {
+			e.printStackTrace();
+		}
+	}
+
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,4 +1,5 @@
 rootProject.name = 'ENG1'
 include 'game'
 include 'game:desktop'
+include 'game:tests'
 include 'game:core'


### PR DESCRIPTION
Second attempt to set up unit tests (see #4).

This builds off [TomGrills](https://github.com/TomGrill/gdx-testing)' skeleton code to setup the unit tests for the game.

I also included some initial asset tests for the character assets (pngs) which I was using to test it worked.
Changes to:

`README.md`
This was updated to include a reference to the skeleton code.

`settings.gradle`
This was updated to declare the tests project in the gradle settings. This ensures that gradle is aware of it during compilation.

`game/build.gradle`
This update adds the tests projects to the main build.gradle for the game.

`game/tests/build.gradle`
This defines a few basic settings for the tests project.

`game/tests/src/com/eng1/gdxtesting/GdxTestRunner.java`
This helps with the testing process by setting up LibGDX Game in a headless manner, so that LibGDX functions can be used and tested.

`game/tests/src/com/eng1/gdxtesting/AssetTests.java`
Intial asset tests.

`.gitignore`
Added `/tests/build/` so git ignores the test project's build files.